### PR TITLE
Print out version of boto3 and botocore used in Lambda

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore
 
 from wells.database import record_to_db
 
@@ -6,6 +7,9 @@ s3 = boto3.client("s3")
 
 
 def lambda_handler(event, context):
+    print(f'boto3 version: {boto3.__version__}')
+    print(f'botocore version: {botocore.__version__}')
+
     bucket = event["Records"][0]["s3"]["bucket"]["name"]
     key = event["Records"][0]["s3"]["object"]["key"]
 


### PR DESCRIPTION
AWS does not tell us what version of boto3 it uses but suggests we print it out to find out ourselves. We want to do this so we can adjust our version of boto3 in our depedency.